### PR TITLE
fixed a case where a '/' wasn't inserted between paths, leading to pu…

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectContentHandlerBase.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectContentHandlerBase.cs
@@ -187,7 +187,14 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                 if (fileConnector.Parameters.ContainsKey(FileConnectorBase.CONTAINER))
                 {
-                    container = string.Concat(fileConnector.GetContainer(), container);
+                    if (!fileConnector.GetContainer().EndsWith("/") && !(container.StartsWith("/") || container.StartsWith("\\")))
+                    {
+                        container = string.Concat(fileConnector.GetContainer() + "/", container);
+                    }
+                    else
+                    {
+                        container = string.Concat(fileConnector.GetContainer(), container);
+                    }
                 }
 
                 using (Stream s = connector.GetFileStream(fileName, folderPath))


### PR DESCRIPTION
…blishing files not being stored in the correct folder

(ex.

4143/4879/5f03577a-1250-40e7-acbd-cbfc404b2390_catalogs/masterpage/ instead of 4143/4879/5f03577a-1250-40e7-acbd-cbfc404b2390/_catalogs/masterpage/)

notice the missing slash between the bm guid and _catalogs