### PR TITLE
Skip extraction of Web-Only Limited Access and RestrictedGuest role assignments

### DIFF
--- a/src/lib/PnP.Framework/Extensions/SecurityExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/SecurityExtensions.cs
@@ -1458,7 +1458,7 @@ namespace Microsoft.SharePoint.Client
                 }
                 foreach (var assignment in obj.RoleAssignments)
                 {
-                    var bindings = web.Context.LoadQuery(assignment.RoleDefinitionBindings.Where(b => b.Name != "Limited Access"));
+                    var bindings = web.Context.LoadQuery(assignment.RoleDefinitionBindings.Where(b => b.Name != "Limited Access" && b.Name != "Web-Only Limited Access"));
                     web.Context.Load(assignment.Member, m => m.LoginName, m => m.Title, m => m.PrincipalType, m => m.Id);
                     web.Context.ExecuteQueryRetry();
                     var bindingList = (from b in bindings select b.Name).ToList();
@@ -1546,7 +1546,7 @@ namespace Microsoft.SharePoint.Client
 
                 if (assignment != null)
                 {
-                    var bindings = web.Context.LoadQuery(assignment.RoleDefinitionBindings.Where(b => b.Name != "Limited Access"));
+                    var bindings = web.Context.LoadQuery(assignment.RoleDefinitionBindings.Where(b => b.Name != "Limited Access" && b.Name != "Web-Only Limited Access"));
                     web.Context.Load(assignment.Member, m => m.LoginName, m => m.Title, m => m.PrincipalType, m => m.Id);
                     web.Context.ExecuteQueryRetry();
 

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Extensions/SecurableObjectExtensions.cs
@@ -180,14 +180,20 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Extensions
                         {
                             foreach (var roleDefinition in roleAssignment.RoleDefinitionBindings)
                             {
-                                if (roleDefinition.RoleTypeKind != RoleType.Guest)
+                                var isGuest = roleDefinition.RoleTypeKind == RoleType.Guest;
+                                var isRestrictedGuest = roleDefinition.RoleTypeKind == RoleType.RestrictedGuest;
+                                var isWebOnlyLimitedAccess = string.Equals(roleDefinition.Name, "Web-Only Limited Access", StringComparison.OrdinalIgnoreCase);
+
+                                if (isGuest || isRestrictedGuest || isWebOnlyLimitedAccess)
                                 {
-                                    security.RoleAssignments.Add(new Model.RoleAssignment()
-                                    {
-                                        Principal = ReplaceGroupTokens(context.Web, roleAssignment.Member.LoginName),
-                                        RoleDefinition = roleDefinition.Name
-                                    });
+                                    continue;
                                 }
+
+                                security.RoleAssignments.Add(new Model.RoleAssignment()
+                                {
+                                    Principal = ReplaceGroupTokens(context.Web, roleAssignment.Member.LoginName),
+                                    RoleDefinition = roleDefinition.Name
+                                });
                             }
                         }
                     }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -983,26 +983,32 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         {
                             foreach (var roleDefinition in webRoleAssignment.RoleDefinitionBindings)
                             {
-                                if (roleDefinition.RoleTypeKind != RoleType.Guest)
+                                var isGuest = roleDefinition.RoleTypeKind == RoleType.Guest;
+                                var isRestrictedGuest = roleDefinition.RoleTypeKind == RoleType.RestrictedGuest;
+                                var isWebOnlyLimitedAccess = string.Equals(roleDefinition.Name, "Web-Only Limited Access", StringComparison.OrdinalIgnoreCase);
+                                
+                                if (isGuest ||isRestrictedGuest || isWebOnlyLimitedAccess)
                                 {
-                                    var modelRoleAssignment = new Model.RoleAssignment();
-                                    var roleDefinitionValue = roleDefinition.Name;
-                                    if (roleDefinition.RoleTypeKind != RoleType.None)
-                                    {
-                                        // Replace with token
-                                        roleDefinitionValue = $"{{roledefinition:{roleDefinition.RoleTypeKind}}}";
-                                    }
-                                    modelRoleAssignment.RoleDefinition = roleDefinitionValue;
-                                    if (webRoleAssignment.Member.PrincipalType == PrincipalType.SharePointGroup)
-                                    {
-                                        modelRoleAssignment.Principal = ReplaceGroupTokens(web, webRoleAssignment.Member.LoginName);
-                                    }
-                                    else
-                                    {
-                                        modelRoleAssignment.Principal = webRoleAssignment.Member.LoginName;
-                                    }
-                                    siteSecurity.SiteSecurityPermissions.RoleAssignments.Add(modelRoleAssignment);
+                                    continue;
                                 }
+
+                                var modelRoleAssignment = new Model.RoleAssignment();
+                                var roleDefinitionValue = roleDefinition.Name;
+                                if (roleDefinition.RoleTypeKind != RoleType.None)
+                                {
+                                    // Replace with token
+                                    roleDefinitionValue = $"{{roledefinition:{roleDefinition.RoleTypeKind}}}";
+                                }
+                                modelRoleAssignment.RoleDefinition = roleDefinitionValue;
+                                if (webRoleAssignment.Member.PrincipalType == PrincipalType.SharePointGroup)
+                                {
+                                    modelRoleAssignment.Principal = ReplaceGroupTokens(web, webRoleAssignment.Member.LoginName);
+                                }
+                                else
+                                {
+                                    modelRoleAssignment.Principal = webRoleAssignment.Member.LoginName;
+                                }
+                                siteSecurity.SiteSecurityPermissions.RoleAssignments.Add(modelRoleAssignment);
                             }
                         }
                     }


### PR DESCRIPTION
• ObjectSiteSecurity.ExtractObjects: skip role assignments where RoleTypeKind == RestrictedGuest or roleDefinition.Name == "Web-Only Limited Access".
• SecurableObjectExtensions.GetSecurity: same skip logic for object-level security extraction.
• SecurityExtensions: exclude "Web-Only Limited Access" and "Limited Access" from RoleDefinitionBindings when loading assignments.