### PR TITLE
Update PnP.Core version and improve WebPartId handling

### DIFF
--- a/src/lib/PnP.Framework.Test/PnP.Framework.Test.csproj
+++ b/src/lib/PnP.Framework.Test/PnP.Framework.Test.csproj
@@ -186,7 +186,7 @@
 		<PackageReference Include="PrivateObjectExtensions" Version="1.4.0" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.0" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.0" />
-		<PackageReference Include="PnP.Core" Version="1.15.0" Condition="'$(PnPCoreSdkPath)' == ''" />
+		<PackageReference Include="PnP.Core" Version="1.15.269-nightly" Condition="'$(PnPCoreSdkPath)' == ''" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -318,8 +318,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                                     if (Guid.TryParse((control as PnPCore.IPageWebPart).WebPartId, out Guid webPartId))
                                     {
                                         // set ControlId to webpart id
-                                        //controlInstance.ControlId = Guid.Parse((control as Pages.ClientSideWebPart).WebPartId);
-                                        controlInstance.ControlId = Guid.Parse((control as PnPCore.IPageWebPart).WebPartId);
+                                        controlInstance.ControlId = webPartId;
                                         //var webPartType = Pages.ClientSidePage.NameToClientSideWebPartEnum((control as Pages.ClientSideWebPart).WebPartId);
                                         var webPartType = pageToExtract.WebPartIdToDefaultWebPart((control as PnPCore.IPageWebPart).WebPartId);
                                         switch (webPartType)
@@ -424,9 +423,15 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                                     }
                                     else
                                     {
-                                        if ((control as PnPCore.IPageWebPart).ControlType != 14)
+                                        // SectionBackgroundControl (controlType 14) has an empty WebPartId — preserve it for round-trip provisioning
+                                        if ((control as PnPCore.IPageWebPart).ControlType == 14)
+                                        {
+                                            controlInstance.Type = WebPartType.Custom;
+                                        }
+                                        else
                                         {
                                             scope.LogWarning("Control with ControlType {0} on page has no valid WebPartId Guid", (control as PnPCore.IPageWebPart).ControlType);
+                                            continue;
                                         }
                                     }
 
@@ -509,7 +514,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                                 Order = headerControl.Order,
                             };
 
-                            controlInstance.ControlId = Guid.Parse((headerControl as PnPCore.IPageWebPart).WebPartId);
+                            // Skip controls with empty/invalid WebPartId (e.g. SectionBackgroundControl)
+                            if (!Guid.TryParse((headerControl as PnPCore.IPageWebPart).WebPartId, out var headerWebPartGuid))
+                            {
+                                continue;
+                            }
+
+                            controlInstance.ControlId = headerWebPartGuid;
                             controlInstance.Type = WebPartType.Custom;
 
                             string jsonControlData = "\"id\": \"" + (headerControl as PnPCore.IPageWebPart).WebPartId + "\", \"instanceId\": \"" + (headerControl as PnPCore.IPageWebPart).InstanceId + "\", \"title\": " + JsonConvert.ToString((headerControl as PnPCore.IPageWebPart).Title) + ", \"description\": " + JsonConvert.ToString((headerControl as PnPCore.IPageWebPart).Description) + ", \"dataVersion\": \"" + (headerControl as PnPCore.IPageWebPart).DataVersion + "\", \"properties\": " + (headerControl as PnPCore.IPageWebPart).PropertiesJson + "";


### PR DESCRIPTION
- Bump PnP.Core NuGet package to 1.15.269-nightly.
- Simplify ControlId assignment by reusing parsed Guid.
- Preserve SectionBackgroundControl (ControlType 14) with empty WebPartId for round-trip provisioning.
- Skip and warn on other controls with invalid WebPartId.
- Prevent errors by skipping header controls with invalid WebPartId.